### PR TITLE
fix(*): avoid error when overlay is empty

### DIFF
--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -459,7 +459,7 @@ class HighlightBuilder {
     if (opaque) return
 
     let mounted = cursor.tree && cursor.tree.prop(NodeProp.mounted)
-    if (mounted && mounted.overlay) {
+    if (mounted && mounted.overlay && mounted.overlay.length > 0) {
       let inner = cursor.node.enter(mounted.overlay[0].from + start, 1)!
       let hasChild = cursor.firstChild()
       for (let i = 0, pos = start;; i++) {


### PR DESCRIPTION
It fixes the error: CodeMirror plugin crashed: TypeError: Cannot read property 'from' of undefined

As I reported here: https://discuss.codemirror.net/t/upgrading-0-19-0-issues/3439
The PR should fix it.
